### PR TITLE
Fix ReducedUniformPoint Edge Cases

### DIFF
--- a/src/generic_layers/reduced_points.rs
+++ b/src/generic_layers/reduced_points.rs
@@ -61,7 +61,7 @@ impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for ReducedUniformPoin
             .points
         {
             for other in raw_points.get_range(Bounds {
-                min: p.position(),
+                min: p.position() - Point2d::splat(p.radius()),
                 max: p.position() + Point2d::splat(p.radius()),
             }) {
                 for other in other.points {

--- a/src/generic_layers/reduced_points.rs
+++ b/src/generic_layers/reduced_points.rs
@@ -76,6 +76,7 @@ impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for ReducedUniformPoin
                             .then_with(|| p.position().cmp(&other.position()))
                             .is_lt();
 
+                    // skip current point if another point's center is within our radius and we have lower priority
                     if other.position().manhattan_dist(p.position()) < p.radius()
                         && lower_priority
                     {

--- a/src/generic_layers/reduced_points.rs
+++ b/src/generic_layers/reduced_points.rs
@@ -76,7 +76,7 @@ impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for ReducedUniformPoin
                             .then_with(|| p.position().cmp(&other.position()))
                             .is_lt();
 
-                    if other.position().manhattan_dist(p.position()) < p.radius() + other.radius()
+                    if other.position().manhattan_dist(p.position()) < p.radius()
                         && lower_priority
                     {
                         continue 'points;

--- a/src/generic_layers/reduced_points.rs
+++ b/src/generic_layers/reduced_points.rs
@@ -61,10 +61,9 @@ impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for ReducedUniformPoin
             .get_or_compute(index.into_same_chunk_size())
             .points
         {
-            for other in raw_points.get_range(Bounds {
-                min: p.position() - Point2d::splat(p.radius()),
-                max: p.position() + Point2d::splat(p.radius()),
-            }) {
+            for other in raw_points.get_range(
+                Bounds::point(p.position()).pad(Point2d::splat(p.radius() + P::RADIUS_RANGE.end))
+            ) {
                 for other in other.points {
                     if other == p {
                         continue;
@@ -77,7 +76,7 @@ impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for ReducedUniformPoin
                             .is_lt();
 
                     // skip current point if another point's center is within our radius and we have lower priority
-                    if other.position().manhattan_dist(p.position()) < p.radius()
+                    if other.position().manhattan_dist(p.position()) < p.radius() + other.radius()
                         && lower_priority
                     {
                         continue 'points;


### PR DESCRIPTION
*(First I want to say thanks for porting this library! I remember seeing the original when it first came out and thinking the idea had a lot of potential so it's cool to see it grow)*

This PR fixes a couple issues I noticed with ReducedUniformPoint:

- The bounds weren't centered on the point
(was like this:)
![image](https://github.com/user-attachments/assets/9d9c300f-d086-4343-8597-e4cacc831667)

- If both points had the same radius, neither was getting removed
With this PR, if they have the same radius it removes the one with the lower X coordinate, or the lower Y coordinate if the X also matches.

- Inconsistent distance check (this is kind of convoluted but I did notice it while trying stuff out)
Say we have this scenario (square is bounds, orange line is chunk boundary):
![image](https://github.com/user-attachments/assets/366185b5-d77a-487c-82ce-83ca334f47e0)
Currently, both points will detect each other, and since it adds their radius together it thinks they're too close, in this case say the top one is 1 unit smaller so it removes itself.
Now consider if the chunk boundary was here instead:
![image](https://github.com/user-attachments/assets/21f45ac7-6840-4b09-9542-ba84ab41d2d7)
Now only the bottom one detects the top one, and since it adds their radius together it thinks they're too close, but since the bottom one is larger it doesn't remove itself, so nothing happens.<br/>
The easiest solve here is to just change the distance condition so this is allowed
So with this PR it basically works so that for each point, no other point's center will be inside its radius
(I could be mistaken but I'm pretty sure to correctly make it so no radius overlaps another point's radius you would need to know an upper bound for radius)

(Note: I didn't change it using manhattan_dist since I assume that's an intentional tradeoff? but obviously that also causes inaccuracies compared to dist_squared)
