### PR TITLE
Add runtime Seed to `UniformPoint`/`ReducedUniformPoint`/`rng_for_point`

### DIFF
--- a/examples/infinite_roads.rs
+++ b/examples/infinite_roads.rs
@@ -26,7 +26,7 @@ struct City {
 
 impl From<Point2d> for City {
     fn from(center: Point2d) -> Self {
-        let mut rng = rng_for_point::<0, _>(center);
+        let mut rng = rng_for_point::<0, _>(center, 0);
         let size = Self::RADIUS_RANGE.sample_single(&mut rng).unwrap();
         let n = 10 * size as i64 / Self::RADIUS_RANGE.end as i64;
         City {

--- a/examples/infinite_roads.rs
+++ b/examples/infinite_roads.rs
@@ -26,7 +26,7 @@ struct City {
 
 impl From<Point2d> for City {
     fn from(center: Point2d) -> Self {
-        let mut rng = rng_for_point::<0, _>(center, 0);
+        let mut rng = rng_for_point::<0, _>(center, Seed(0));
         let size = Self::RADIUS_RANGE.sample_single(&mut rng).unwrap();
         let n = 10 * size as i64 / Self::RADIUS_RANGE.end as i64;
         City {

--- a/src/generic_layers.rs
+++ b/src/generic_layers.rs
@@ -4,7 +4,7 @@ use arrayvec::ArrayVec;
 use rand::prelude::*;
 
 use crate::{
-    Bounds, Chunk, ChunkExt as _,
+    Bounds, Chunk, ChunkExt as _, Seed,
     debug::{Debug, DebugContent},
     rolling_grid::GridPoint,
     vec2::{Num, Point2d},
@@ -48,18 +48,18 @@ impl<P, const SIZE: u8, const SALT: u64> Default for UniformPoint<P, SIZE, SALT>
 
 impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for UniformPoint<P, SIZE, SALT> {
     type LayerStore<T> = T;
-    type Dependencies = ();
+    type Dependencies = Seed;
 
     const SIZE: Point2d<u8> = Point2d::splat(SIZE);
 
-    fn compute((): &Self::Dependencies, index: GridPoint<Self>) -> Self {
-        let points = generate_points::<SALT, Self>(index);
+    fn compute(Seed(seed): &Self::Dependencies, index: GridPoint<Self>) -> Self {
+        let points = generate_points::<SALT, Self>(index, *seed);
         Self {
             points: points.map(P::from).collect(),
         }
     }
 
-    fn clear((): &Self::Dependencies, _index: GridPoint<Self>) {
+    fn clear(Seed(_): &Self::Dependencies, _index: GridPoint<Self>) {
         // Nothing to do, we do not have dependencies
     }
 }
@@ -72,20 +72,22 @@ impl<P: Reducible, const SIZE: u8, const SALT: u64> Debug for UniformPoint<P, SI
 
 fn generate_points<const SALT: u64, C: Chunk + 'static>(
     index: GridPoint<C>,
+    seed: u64,
 ) -> impl Iterator<Item = Point2d> {
     let chunk_bounds = C::bounds(index);
-    let mut rng = rng_for_point::<SALT, _>(index);
+    let mut rng = rng_for_point::<SALT, _>(index, seed);
     let n = poisson_1(rng.random_range(0.0..=1.0)).into();
     std::iter::from_fn(move || Some(chunk_bounds.sample(&mut rng))).take(n)
 }
 
 /// Create a random number generator seeded with a specific point.
-pub fn rng_for_point<const SALT: u64, T: Num>(index: Point2d<T>) -> SmallRng {
+pub fn rng_for_point<const SALT: u64, T: Num>(index: Point2d<T>, seed: u64) -> SmallRng {
     let x = SmallRng::seed_from_u64(index.x.as_u64());
     let y = SmallRng::seed_from_u64(index.y.as_u64());
     let salt = SmallRng::seed_from_u64(SALT);
+    let seeded = SmallRng::seed_from_u64(seed);
     let mut seed = <SmallRng as SeedableRng>::Seed::default();
-    for mut rng in [x, y, salt] {
+    for mut rng in [x, y, salt, seeded] {
         let mut tmp = <SmallRng as SeedableRng>::Seed::default();
         rng.fill_bytes(&mut tmp);
         for (seed, tmp) in seed.iter_mut().zip(tmp.iter()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,16 @@ impl<C: Chunk + debug::Debug> Dependencies for Layer<C> {
     }
 }
 
+/// Wrapper around a [`u64`] seed so it can be used as [`Dependencies`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Seed(pub u64);
+
+impl Dependencies for Seed {
+    fn debug(&self) -> Vec<&dyn crate::debug::DynLayer> {
+        vec![]
+    }
+}
+
 /// The entry point to access the chunks of a layer.
 ///
 /// It exposes various convenience accessors, like iterating over areas in


### PR DESCRIPTION
Adds a way to pass a runtime seed into `UniformPoint`/`ReducedUniformPoint`/`rng_for_point`
Afaik there wasn't a way to vary the seed of these at runtime (eg. different world seeds in a game), other than reimplementing them yourself

This PR adds a `Seed` struct that just wraps a u64 and impls `Dependencies`, which is used in `UniformPoint` instead of `()`
And that gets passed down into `rng_for_point`, which now takes in a `seed: u64` and factors that in

Changing the `Dependencies` of `UniformPoint` and adding the param to `rng_for_point` are (easily fixable) breaking changes
I implemented `Default` for `Seed` (zero) to not break the basic case of creating the whole `Layer` with `default()`
(though note that the default will result in a different constant seed than before this PR)
