### PR TITLE
Make Reducible more flexible

### DIFF
--- a/src/generic_layers.rs
+++ b/src/generic_layers.rs
@@ -48,14 +48,14 @@ impl<P, const SIZE: u8, const SALT: u64> Default for UniformPoint<P, SIZE, SALT>
 
 impl<P: Reducible, const SIZE: u8, const SALT: u64> Chunk for UniformPoint<P, SIZE, SALT> {
     type LayerStore<T> = T;
-    type Dependencies = Seed;
+    type Dependencies = (Seed, P::Dependencies);
 
     const SIZE: Point2d<u8> = Point2d::splat(SIZE);
 
-    fn compute(&seed: &Self::Dependencies, index: GridPoint<Self>) -> Self {
-        let points = generate_points::<SALT, Self>(index, seed);
+    fn compute((seed, ctx): &Self::Dependencies, index: GridPoint<Self>) -> Self {
+        let points = generate_points::<SALT, Self>(index, *seed);
         Self {
-            points: points.map(P::from).collect(),
+            points: points.filter_map(|p| P::try_new(p, ctx)).collect(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,12 @@ impl Dependencies for Seed {
     }
 }
 
+impl<D: Dependencies> Dependencies for (Seed, D) {
+    fn debug(&self) -> Vec<&dyn DynLayer> {
+        self.1.debug()
+    }
+}
+
 /// The entry point to access the chunks of a layer.
 ///
 /// It exposes various convenience accessors, like iterating over areas in


### PR DESCRIPTION
Some changes to `Reducible` to make it more powerful/flexible:
- Added `try_new` fn instead of requiring `From<Point2d>`, so you can filter out points before reduction
- Added `Dependencies` AT to `Reducible` that gets stored in `UniformPoint`'s Dependencies, and gets passed into `try_new`
  - Allows passing in context from outside (seed, other layers, custom configs, etc) which wasn't possible before
- Replaced the `RADIUS_RANGE` const with a `max_radius` fn that takes in `&Dependencies`, so you can have the max radius depend on outside context
- Added a `priority` fn which defaults to returning `self.radius()`, but can be overridden to change the overlap priority function

lmk if you have any thoughts :)

Example of using this stuff to make a reusable layer type where you can have multiple instances with different configs:
```rs
pub struct BlobsConfig {
    pub size_range: Range<i64>,
    pub pad_radius: i16,
}

impl Dependencies for BlobsConfig {
    fn debug(&self) -> Vec<&dyn debug::DynLayer> {
        vec![]
    }
}

#[derive(Debug, Default, Clone, Copy, PartialEq)]
pub struct Blob {
    pub center: Point2d,
    pub size: i64,
    pub pad_radius: i16,
    pub priority: i64,
}

impl Reducible for Blob {
    type Dependencies = (Seed, BlobsConfig);

    fn try_new(center: Point2d, (seed, config): &Self::Dependencies) -> Option<Self> {
        let mut rng = generic_layers::rng_for_point::<0, _>(center, *seed);
        let size = config.size_range.clone().sample_single(&mut rng).unwrap();
        // reduce number of large blobs
        // (could just change the random distribution but for demonstration purposes)
        if rng.random_bool(size as f64 / config.size_range.end as f64) {
            return None;
        }
        Some(Blob {
            center,
            size,
            // priority detached from size to give smaller blobs a better chance
            priority: rng.random_range(0..100),
            pad_radius: config.pad_radius,
        })
    }

    fn max_radius((_, config): &Self::Dependencies) -> i64 {
        config.size_range.end + config.pad_radius as i64
    }

    fn radius(&self) -> i64 {
        self.size + self.pad_radius as i64
    }

    fn priority(&self) -> i64 {
        self.priority
    }

    fn position(&self) -> Point2d {
        self.center
    }

    fn debug(&self, _bounds: Bounds) -> Vec<DebugContent> {
        vec![
            DebugContent::Circle { center: self.center, radius: self.radius() as f32 },
            DebugContent::Circle { center: self.center, radius: self.size as f32 },
        ]
    }
}

type Blobs = ReducedUniformPoint<Blob, 5, 2>;

fn example() {
    // small blobs with extra padding
    let blobs_1: Layer<Blobs> = Layer::new(Layer::new((
        Seed(0),
        (
            Seed(0),
            BlobsConfig { size_range: 10..20, pad_radius: 8 },
        ),
    )));

    // larger blobs with negative padding so they can intersect
    let blobs_2: Layer<Blobs> = Layer::new(Layer::new((
        Seed(1),
        (
            Seed(1),
            BlobsConfig { size_range: 20..40, pad_radius: -4 },
        ),
    )));
}
```